### PR TITLE
fix: skip Optional types and correctly wrap bundle in array

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -51,15 +51,24 @@ pub struct BundleRequest {
     #[serde(serialize_with = "serialize_txs")]
     transactions: Vec<BundleTransaction>,
     #[serde(rename = "revertingTxHashes")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     revertible_transaction_hashes: Vec<H256>,
 
     #[serde(rename = "blockNumber")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     target_block: Option<U64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     min_timestamp: Option<u64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_timestamp: Option<u64>,
 
     #[serde(rename = "stateBlockNumber")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     simulation_block: Option<U64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "timestamp")]
     simulation_timestamp: Option<u64>,
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -117,7 +117,7 @@ impl<M: Middleware, S: Signer> FlashbotsMiddleware<M, S> {
         bundle: &BundleRequest,
     ) -> Result<SimulatedBundle, FlashbotsMiddlewareError<M, S>> {
         self.relay
-            .request("eth_callBundle", bundle)
+            .request("eth_callBundle", [bundle])
             .await
             .map_err(FlashbotsMiddlewareError::RelayError)
     }
@@ -134,7 +134,7 @@ impl<M: Middleware, S: Signer> FlashbotsMiddleware<M, S> {
     {
         let response: SendBundleResponse = self
             .relay
-            .request("eth_sendBundle", bundle)
+            .request("eth_sendBundle", [bundle])
             .await
             .map_err(FlashbotsMiddlewareError::RelayError)?;
 


### PR DESCRIPTION
As title, tried using it live today and identified these bugs