### PR TITLE
Bump ethers-rs version to add Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+- Upgraded Ethers to 0.5.2 and disabled default features to allow for building on Windows (which lacks IPC support, see https://github.com/gakonst/ethers-rs/issues/393)
+
 ## [0.5.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,9 @@ futures-core = "0.3"
 pin-project = "1"
 
 # Ethers
-ethers-core = "0.5.1"
-ethers-signers = "0.5.1"
-ethers-providers = "0.5.1"
+ethers = {version = "0.5.2", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.7.1", features = ["macros", "rt-multi-thread"] }
-ethers = "0.5.1"
+ethers = {version = "0.5.2", default-features = false }
 anyhow = "1.0"

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,6 +1,6 @@
 use crate::utils::{deserialize_optional_h160, deserialize_u256, deserialize_u64};
 use chrono::{DateTime, Utc};
-use ethers_core::{
+use ethers::core::{
     types::{transaction::response::Transaction, Address, Bytes, TxHash, H256, U256, U64},
     utils::keccak256,
 };

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,7 +1,7 @@
 // Code adapted from: https://github.com/althea-net/guac_rs/tree/master/web3/src/jsonrpc
 // NOTE: This module only exists since there is no way to use the data structures
 // in the `ethers-providers/src/transports/common.rs` from another crate.
-use ethers_core::types::U256;
+use ethers::core::types::U256;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -5,12 +5,12 @@ use crate::{
     UserStats,
 };
 use async_trait::async_trait;
-use ethers_core::{
+use ethers::core::{
     types::{BlockNumber, Bytes, U64},
     utils::keccak256,
 };
-use ethers_providers::{FromErr, Middleware, PendingTransaction};
-use ethers_signers::Signer;
+use ethers::providers::{FromErr, Middleware, PendingTransaction};
+use ethers::signers::Signer;
 use thiserror::Error;
 use url::Url;
 

--- a/src/pending_bundle.rs
+++ b/src/pending_bundle.rs
@@ -1,6 +1,6 @@
 use crate::bundle::BundleHash;
-use ethers_core::types::{Block, TxHash, U64};
-use ethers_providers::{
+use ethers::core::types::{Block, TxHash, U64};
+use ethers::providers::{
     interval, JsonRpcClient, Middleware, Provider, ProviderError, DEFAULT_POLL_INTERVAL,
 };
 use futures_core::stream::Stream;

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -2,11 +2,11 @@ use crate::{
     bundle::BundleHash,
     jsonrpc::{JsonRpcError, Request, Response},
 };
-use ethers_core::{
+use ethers::core::{
     types::{H256, U64},
     utils::keccak256,
 };
-use ethers_signers::Signer;
+use ethers::signers::Signer;
 use reqwest::{Client, Error as ReqwestError};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,5 @@
 use crate::utils::deserialize_u256;
-use ethers_core::types::U256;
+use ethers::core::types::U256;
 use serde::Deserialize;
 
 /// Represents stats for a searcher.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use ethers_core::types::{H160, U256, U64};
+use ethers::core::types::{H160, U256, U64};
 use serde::{de, Deserialize};
 use serde_json::Value;
 use std::str::FromStr;


### PR DESCRIPTION
Hi,

The previous version of Ethers (0.5.1) is unable to build on Windows due to a lack of IPC support (which it assumes). By upgrading to 0.5.2 and disabling the default features this crate works again.

For context see: https://github.com/gakonst/ethers-rs/issues/393#issuecomment-944389805

Kind regards,

Tim