### PR TITLE
chore: use latest ethers patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ futures-core = "0.3"
 pin-project = "1"
 
 # Ethers
-ethers-core = "0.5.1"
-ethers-signers = "0.5.1"
-ethers-providers = "0.5.1"
+ethers-core = "^0.5.0"
+ethers-signers = "^0.5.0"
+ethers-providers = "^0.5.0"
 
 [dev-dependencies]
 tokio = { version = "1.7.1", features = ["macros", "rt-multi-thread"] }
-ethers = "0.5.1"
+ethers = "^0.5.0"
 anyhow = "1.0"


### PR DESCRIPTION
as title