### PR TITLE
Bump ethers dependency to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ futures-core = "0.3"
 pin-project = "1"
 
 # Ethers
-ethers = {version = "^0.5.0", default-features = false }
+ethers = {version = "^0.6.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.7.1", features = ["macros", "rt-multi-thread"] }
-ethers = {version = "^0.5.0", default-features = false }
+ethers = {version = "^0.6.0", default-features = false }
 anyhow = "1.0"


### PR DESCRIPTION
With a recent version of rust (e.g. 1.57.0), build of ethers-flashbots fails with:

       Compiling ethers-providers v0.5.5
    error: 1 positional argument in format string, but no arguments were given
      --> .cargo/registry/src/github.com-1ecc6299db9ec823/ethers-contract-abigen-0.5.4/src/source.rs:93:46
       |
    93 |             .map_err(|_| anyhow!("root path '{}' is not absolute"))?;

This is simply fixed by bumping ethers to 0.6.