### PR TITLE
Switch to specific ethers packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,10 @@ futures-core = "0.3"
 pin-project = "1"
 
 # Ethers
-ethers = {version = "^0.6.0", default-features = false }
+ethers-providers ="*"
+ethers-middleware ="*"
+ethers-core = "*"
+ethers-signers = "*"
 
 [dev-dependencies]
 tokio = { version = "1.7.1", features = ["macros", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ethers-flashbots = { git = "https://github.com/onbjerg/ethers-flashbots" }
 
 ```rs
 use anyhow::Result;
-use ethers::core::rand::thread_rng;
+use  ethers_core::rand::thread_rng;
 use ethers::prelude::*;
 use ethers_flashbots::*;
 use std::convert::TryFrom;

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use ethers::core::{rand::thread_rng, types::transaction::eip2718::TypedTransaction};
 use ethers::prelude::*;
+use ethers_core::{rand::thread_rng, types::transaction::eip2718::TypedTransaction};
 use ethers_flashbots::*;
 use std::convert::TryFrom;
 use url::Url;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use ethers::core::rand::thread_rng;
 use ethers::prelude::*;
+use ethers_core::rand::thread_rng;
 use ethers_flashbots::*;
 use std::convert::TryFrom;
 use url::Url;

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1,6 +1,6 @@
 use crate::utils::{deserialize_optional_h160, deserialize_u256, deserialize_u64};
 use chrono::{DateTime, Utc};
-use ethers::core::{
+use ethers_core::{
     types::{transaction::response::Transaction, Address, Bytes, TxHash, H256, U256, U64},
     utils::keccak256,
 };

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -1,7 +1,7 @@
 // Code adapted from: https://github.com/althea-net/guac_rs/tree/master/web3/src/jsonrpc
 // NOTE: This module only exists since there is no way to use the data structures
 // in the `ethers-providers/src/transports/common.rs` from another crate.
-use ethers::core::types::U256;
+use ethers_core::types::U256;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! Provides an [ethers](https://docs.rs/ethers) compatible middleware for submitting
 //! [Flashbots](https://docs.flashbots.net) bundles.
 //!
-//! In addition to leveraging the standard Ethers middleware API ([`send_transaction`][ethers::providers::Middleware::send_transaction]),
+//! In addition to leveraging the standard Ethers middleware API ([`send_transaction`][ ethers_providers::Middleware::send_transaction]),
 //! custom bundles can be crafted, simulated and submitted.
 mod bundle;
 pub use bundle::{

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -5,12 +5,12 @@ use crate::{
     UserStats,
 };
 use async_trait::async_trait;
-use ethers::core::{
+use ethers_core::{
     types::{BlockNumber, Bytes, U64},
     utils::keccak256,
 };
-use ethers::providers::{FromErr, Middleware, PendingTransaction};
-use ethers::signers::Signer;
+use ethers_providers::{FromErr, Middleware, PendingTransaction};
+use ethers_signers::Signer;
 use thiserror::Error;
 use url::Url;
 

--- a/src/pending_bundle.rs
+++ b/src/pending_bundle.rs
@@ -1,6 +1,6 @@
 use crate::bundle::BundleHash;
-use ethers::core::types::{Block, TxHash, U64};
-use ethers::providers::{
+use ethers_core::types::{Block, TxHash, U64};
+use ethers_providers::{
     interval, JsonRpcClient, Middleware, Provider, ProviderError, DEFAULT_POLL_INTERVAL,
 };
 use futures_core::stream::Stream;

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -2,11 +2,11 @@ use crate::{
     bundle::BundleHash,
     jsonrpc::{JsonRpcError, Request, Response},
 };
-use ethers::core::{
+use ethers_core::{
     types::{H256, U64},
     utils::keccak256,
 };
-use ethers::signers::Signer;
+use ethers_signers::Signer;
 use reqwest::{Client, Error as ReqwestError};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,5 @@
 use crate::utils::deserialize_u256;
-use ethers::core::types::U256;
+use ethers_core::types::U256;
 use serde::Deserialize;
 
 /// Represents stats for a searcher.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use ethers::core::types::{H160, U256, U64};
+use ethers_core::types::{H160, U256, U64};
 use serde::{de, Deserialize};
 use serde_json::Value;
 use std::str::FromStr;


### PR DESCRIPTION
Ethers-rs doesn't compile under a win32-based environment.  Even if you switch to an alternative toolchain, there are issues.  It's centered around the ethers-solc package and sha-asm2 dependency.  Ethers-flashbots actually consumes very little from the overall ethers-rs package.  If the dependencies were optimized, it would be very awesome for a lot of consumers. 

