### PR TITLE
Bump ethers dependency to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `ethers` to `1.5.0` and fixed middleware breaking changes
+
 ## [0.12.1]
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ futures-core = "0.3"
 pin-project = "1"
 
 # Ethers
-ethers = { version = "1.0.0", default-features = false }
+ethers = { version = "1.5.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
-ethers = { version = "1.0.0", default-features = false }
+ethers = { version = "1.5.0", default-features = false }
 eyre = "0.6"
 
 [features]


### PR DESCRIPTION
Bumped ethers to version 1.5.0 and fixed breaking changes by implementing `MiddlewareError` on type `FlashbotsMiddlewareError<M, S>`