### PR TITLE
Changed advance example to reflect set_simulation_relay and fn set_simulation_relay 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ethers-flashbots"
+name = "ethers-flashbots-test"
 version = "0.13.1"
 authors = ["Oliver Nordbjerg <hi@notbjerg.me>"]
 license = "MIT"

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,6 +1,6 @@
 use ethers::core::{rand::thread_rng, types::transaction::eip2718::TypedTransaction};
 use ethers::prelude::*;
-use ethers_flashbots::*;
+use ethers_flashbots_test::*;
 use eyre::Result;
 use std::convert::TryFrom;
 use url::Url;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use ethers::core::rand::thread_rng;
 use ethers::prelude::*;
-use ethers_flashbots::*;
+use ethers_flashbots_test::*;
 use eyre::Result;
 use std::convert::TryFrom;
 use url::Url;

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -29,6 +29,7 @@ async fn main() -> Result<()> {
     let tx = TransactionRequest::pay("vitalik.eth", 100);
     let pending_tx = client.send_transaction(tx, None).await?;
 
+
     // Get the receipt
     let receipt = pending_tx
         .await?

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -261,7 +261,7 @@ impl BundleRequest {
 ///
 /// Details for a transaction that has been simulated as part of
 /// a bundle.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SimulatedTransaction {
     /// The transaction hash
     #[serde(rename = "txHash")]
@@ -317,7 +317,7 @@ impl SimulatedTransaction {
 /// Details of a simulated bundle.
 ///
 /// The details of a bundle that has been simulated.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SimulatedBundle {
     /// The bundle's hash.
     #[serde(rename = "bundleHash")]

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize, Serializer};
 pub type BundleHash = H256;
 
 /// A transaction that can be added to a bundle.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BundleTransaction {
     /// A pre-signed transaction.
     Signed(Box<Transaction>),

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize, Serializer};
 pub type BundleHash = H256;
 
 /// A transaction that can be added to a bundle.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub enum BundleTransaction {
     /// A pre-signed transaction.
     Signed(Box<Transaction>),

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize, Serializer};
 pub type BundleHash = H256;
 
 /// A transaction that can be added to a bundle.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BundleTransaction {
     /// A pre-signed transaction.
     Signed(Box<Transaction>),
@@ -45,11 +45,11 @@ impl From<Bytes> for BundleTransaction {
 ///
 /// - At least one transaction ([`BundleRequest::push_transaction`])
 /// - A target block ([`BundleRequest::set_block`])
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BundleRequest {
     #[serde(rename = "txs")]
-    #[serde(serialize_with = "serialize_txs")]
+    // #[serde(serialize_with = "serialize_txs")]
     transactions: Vec<BundleTransaction>,
     #[serde(rename = "revertingTxHashes")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -78,20 +78,20 @@ pub struct BundleRequest {
     simulation_basefee: Option<u64>,
 }
 
-pub fn serialize_txs<S>(txs: &[BundleTransaction], s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let raw_txs: Vec<Bytes> = txs
-        .iter()
-        .map(|tx| match tx {
-            BundleTransaction::Signed(inner) => inner.rlp(),
-            BundleTransaction::Raw(inner) => inner.clone(),
-        })
-        .collect();
+// pub fn serialize_txs<S>(txs: &[BundleTransaction], s: S) -> Result<S::Ok, S::Error>
+// where
+//     S: Serializer,
+// {
+//     let raw_txs: Vec<Bytes> = txs
+//         .iter()
+//         .map(|tx| match tx {
+//             BundleTransaction::Signed(inner) => inner.rlp(),
+//             BundleTransaction::Raw(inner) => inner.clone(),
+//         })
+//         .collect();
 
-    raw_txs.serialize(s)
-}
+//     raw_txs.serialize(s)
+// }
 
 impl BundleRequest {
     /// Creates an empty bundle request.

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize, Serializer};
 pub type BundleHash = H256;
 
 /// A transaction that can be added to a bundle.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub enum BundleTransaction {
     /// A pre-signed transaction.
     Signed(Box<Transaction>),
@@ -45,7 +45,7 @@ impl From<Bytes> for BundleTransaction {
 ///
 /// - At least one transaction ([`BundleRequest::push_transaction`])
 /// - A target block ([`BundleRequest::set_block`])
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BundleRequest {
     #[serde(rename = "txs")]

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -261,7 +261,7 @@ impl BundleRequest {
 ///
 /// Details for a transaction that has been simulated as part of
 /// a bundle.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimulatedTransaction {
     /// The transaction hash
     #[serde(rename = "txHash")]
@@ -317,7 +317,7 @@ impl SimulatedTransaction {
 /// Details of a simulated bundle.
 ///
 /// The details of a bundle that has been simulated.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SimulatedBundle {
     /// The bundle's hash.
     #[serde(rename = "bundleHash")]

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize, Serializer};
 pub type BundleHash = H256;
 
 /// A transaction that can be added to a bundle.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BundleTransaction {
     /// A pre-signed transaction.
     Signed(Box<Transaction>),
@@ -45,7 +45,7 @@ impl From<Bytes> for BundleTransaction {
 ///
 /// - At least one transaction ([`BundleRequest::push_transaction`])
 /// - A target block ([`BundleRequest::set_block`])
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BundleRequest {
     #[serde(rename = "txs")]

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -77,7 +77,6 @@ pub struct Response<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(untagged)]
 pub enum ResponseData<R> {
     Error { error: JsonRpcError },
     Success { result: R },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub use user::UserStats;
 mod middleware;
 pub use middleware::{FlashbotsMiddleware, FlashbotsMiddlewareError};
 
-mod jsonrpc;
+pub mod jsonrpc;
 mod relay;
 pub use relay::{Relay, RelayError};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ mod middleware;
 pub use middleware::{FlashbotsMiddleware, FlashbotsMiddlewareError};
 
 pub mod jsonrpc;
-mod relay;
+pub mod relay;
 pub use relay::{Relay, RelayError};
 
 mod utils;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -145,8 +145,8 @@ impl<M: Middleware, S: Signer> FlashbotsMiddleware<M, S> {
     ///
     /// This can either be a full Flashbots relay or a node that implements
     /// the `eth_callBundle` remote procedure call.
-    pub fn set_simulation_relay(&mut self, relay_url: impl Into<Url>) {
-        self.simulation_relay = Some(Relay::new(relay_url, None));
+    pub fn set_simulation_relay(&mut self, relay_url: impl Into<Url>, relay_signer: S) {
+        self.simulation_relay = Some(Relay::new(relay_url, Some(relay_signer)));
     }
 
     /// Simulate a bundle.

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -137,7 +137,7 @@ impl<S: Signer + Clone> Clone for Relay<S> {
     }
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Serialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SendBundleResponse {
     pub(crate) bundle_hash: BundleHash,

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -139,7 +139,7 @@ impl<S: Signer + Clone> Clone for Relay<S> {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct SendBundleResponse {
+pub struct SendBundleResponse {
     pub(crate) bundle_hash: BundleHash,
 }
 

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -100,7 +100,10 @@ impl<S: Signer> Relay<S> {
         }
 
         let res = req.json(&payload).send().await?;
+        print!("response: {:?}", res);
         let status = res.error_for_status_ref();
+        print!("response: {:?}", status);
+
 
         match status {
             Err(err) => {
@@ -116,6 +119,7 @@ impl<S: Signer> Relay<S> {
             }
             Ok(_) => {
                 let text = res.text().await?;
+                print!("test: {:?}", text);
                 let res: Response<R> = serde_json::from_str(&text)
                     .map_err(|err| RelayError::ResponseSerdeJson { err, text })?;
 

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -137,7 +137,7 @@ impl<S: Signer + Clone> Clone for Relay<S> {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SendBundleResponse {
     pub(crate) bundle_hash: BundleHash,

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -100,9 +100,7 @@ impl<S: Signer> Relay<S> {
         }
 
         let res = req.json(&payload).send().await?;
-        print!("response: {:?}", res);
         let status = res.error_for_status_ref();
-        print!("response: {:?}", status);
 
 
         match status {
@@ -119,7 +117,6 @@ impl<S: Signer> Relay<S> {
             }
             Ok(_) => {
                 let text = res.text().await?;
-                print!("test: {:?}", text);
                 let res: Response<R> = serde_json::from_str(&text)
                     .map_err(|err| RelayError::ResponseSerdeJson { err, text })?;
 


### PR DESCRIPTION
After the 0.12.0, to simulate the bundles, users are required to call the `set_simulation_relay` method to set a relay endpoint, otherwise it'll be `None`. 

Additionally, I modified the `set_simulation_relay` method to take one more argument `relay_signer`, otherwise `X-Flashbots-Signature` header won't be set inside of `relay::request`