### PR TITLE
feat: Add replacementUuid support in BundleRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 - Fix simulation for broadcaster middleware (#58)
+- Added support for `replacementUuid` field in `eth_sendBundle`
 
 ## [0.14.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { version = "1.0.37", default-features = false }
 serde = "1"
 serde_json = "1"
 chrono = { version = "0.4.22", features = ["default", "serde"] }
+uuid = "1.5"
 
 # HTTP
 url = { version = "2.3.1", default-features = false }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -5,6 +5,7 @@ use ethers::core::{
     utils::keccak256,
 };
 use serde::{Deserialize, Serialize, Serializer};
+use uuid::Uuid;
 
 /// A bundle hash.
 pub type BundleHash = H256;
@@ -29,7 +30,6 @@ impl From<Bytes> for BundleTransaction {
         Self::Raw(tx)
     }
 }
-
 /// A bundle that can be submitted to a Flashbots relay.
 ///
 /// The bundle can include your own transactions and transactions from
@@ -67,7 +67,8 @@ pub struct BundleRequest {
 
     #[serde(rename = "replacementUuid")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    uuid: Option<String>,
+    #[serde(serialize_with = "serialize_uuid_as_string")]
+    uuid: Option<Uuid>,
 
     #[serde(rename = "stateBlockNumber")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -80,6 +81,15 @@ pub struct BundleRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "baseFee")]
     simulation_basefee: Option<u64>,
+}
+
+fn serialize_uuid_as_string<S>(x: &Option<Uuid>, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    // Don't need to handle None option here as handled by
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    s.serialize_str(&x.unwrap().to_string())
 }
 
 pub fn serialize_txs<S>(txs: &[BundleTransaction], s: S) -> Result<S::Ok, S::Error>
@@ -175,14 +185,14 @@ impl BundleRequest {
     }
 
     /// Get a reference to the replacement uuid (if any).
-    pub fn uuid(&self) -> &Option<String> {
+    pub fn uuid(&self) -> &Option<Uuid> {
         &self.uuid
     }
 
     /// Set the replacement uuid of the bundle.
     /// This is used for bundle replacements or cancellations using eth_cancelBundle
-    pub fn set_uuid(mut self, uuid: String) -> Self {
-        self.uuid = Some(uuid.clone());
+    pub fn set_uuid(mut self, uuid: Uuid) -> Self {
+        self.uuid = Some(uuid);
         self
     }
 
@@ -418,6 +428,7 @@ pub struct BuilderEntry {
 mod tests {
     use super::*;
     use std::str::FromStr;
+    use uuid::uuid;
 
     #[test]
     fn bundle_serialize() {
@@ -448,14 +459,14 @@ mod tests {
             .set_simulation_timestamp(1000)
             .set_simulation_block(1.into())
             .set_simulation_basefee(333333)
-            .set_uuid("UuidString".to_string());
+            .set_uuid(uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"));
 
         bundle.add_transaction(Bytes::from(vec![0x3]));
         bundle.add_revertible_transaction(Bytes::from(vec![0x4]));
 
         assert_eq!(
             &serde_json::to_string(&bundle).unwrap(),
-            r#"{"txs":["0x01","0x02","0x03","0x04"],"revertingTxHashes":["0xf2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2","0xf343681465b9efe82c933c3e8748c70cb8aa06539c361de20f72eac04e766393"],"blockNumber":"0x2","minTimestamp":1000,"maxTimestamp":2000,"replacementUuid":"UuidString","stateBlockNumber":"0x1","timestamp":1000,"baseFee":333333}"#
+            r#"{"txs":["0x01","0x02","0x03","0x04"],"revertingTxHashes":["0xf2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2","0xf343681465b9efe82c933c3e8748c70cb8aa06539c361de20f72eac04e766393"],"blockNumber":"0x2","minTimestamp":1000,"maxTimestamp":2000,"replacementUuid":"67e55044-10b1-426f-9247-bb680e5fe0c8","stateBlockNumber":"0x1","timestamp":1000,"baseFee":333333}"#
         );
     }
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -65,6 +65,10 @@ pub struct BundleRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     max_timestamp: Option<u64>,
 
+    #[serde(rename = "replacementUuid")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uuid: Option<String>,
+
     #[serde(rename = "stateBlockNumber")]
     #[serde(skip_serializing_if = "Option::is_none")]
     simulation_block: Option<U64>,
@@ -168,6 +172,18 @@ impl BundleRequest {
                 BundleTransaction::Raw(inner) => keccak256(inner).into(),
             })
             .collect()
+    }
+
+    /// Get a reference to the replacement uuid (if any).
+    pub fn uuid(&self) -> &Option<String> {
+        &self.uuid
+    }
+
+    /// Set the replacement uuid of the bundle.
+    /// This is used for bundle replacements or cancellations using eth_cancelBundle
+    pub fn set_uuid(mut self, uuid: String) -> Self {
+        self.uuid = Some(uuid.clone());
+        self
     }
 
     /// Get the target block (if any).
@@ -431,14 +447,15 @@ mod tests {
             .set_max_timestamp(2000)
             .set_simulation_timestamp(1000)
             .set_simulation_block(1.into())
-            .set_simulation_basefee(333333);
+            .set_simulation_basefee(333333)
+            .set_uuid("UuidString".to_string());
 
         bundle.add_transaction(Bytes::from(vec![0x3]));
         bundle.add_revertible_transaction(Bytes::from(vec![0x4]));
 
         assert_eq!(
             &serde_json::to_string(&bundle).unwrap(),
-            r#"{"txs":["0x01","0x02","0x03","0x04"],"revertingTxHashes":["0xf2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2","0xf343681465b9efe82c933c3e8748c70cb8aa06539c361de20f72eac04e766393"],"blockNumber":"0x2","minTimestamp":1000,"maxTimestamp":2000,"stateBlockNumber":"0x1","timestamp":1000,"baseFee":333333}"#
+            r#"{"txs":["0x01","0x02","0x03","0x04"],"revertingTxHashes":["0xf2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f2","0xf343681465b9efe82c933c3e8748c70cb8aa06539c361de20f72eac04e766393"],"blockNumber":"0x2","minTimestamp":1000,"maxTimestamp":2000,"replacementUuid":"UuidString","stateBlockNumber":"0x1","timestamp":1000,"baseFee":333333}"#
         );
     }
 


### PR DESCRIPTION
Add support for sending bundles with uuids for future replacement/cancellations. Will probably at some point also figure out how to get eth_cancelBundle into this crate.

https://docs.flashbots.net/flashbots-auction/advanced/rpc-endpoint