### PR TITLE
Make response's data field 'optional'

### DIFF
--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -80,12 +80,12 @@ pub struct Response<T> {
 #[serde(untagged)]
 pub enum ResponseData<R> {
     Error { error: JsonRpcError },
-    Success { result: R },
+    Success { result: Option<R> },
 }
 
 impl<R> ResponseData<R> {
     /// Consume response and return value
-    pub fn into_result(self) -> Result<R, JsonRpcError> {
+    pub fn into_result(self) -> Result<Option<R>, JsonRpcError> {
         match self {
             ResponseData::Success { result } => Ok(result),
             ResponseData::Error { error } => Err(error),
@@ -102,7 +102,15 @@ mod tests {
         let response: Response<u64> =
             serde_json::from_str(r#"{"jsonrpc": "2.0", "result": 19, "id": 1}"#).unwrap();
         assert_eq!(response.id, 1);
-        assert_eq!(response.data.into_result().unwrap(), 19);
+        assert_eq!(response.data.into_result().unwrap(), Some(19));
+    }
+
+    #[test]
+    fn deser_response_without_result() {
+        let response: Response<u64> =
+            serde_json::from_str(r#"{"jsonrpc": "2.0", "id": 1, "result": null}"#).unwrap();
+        assert_eq!(response.id, 1);
+        assert_eq!(response.data.into_result().unwrap(), None);
     }
 
     #[test]

--- a/src/pending_bundle.rs
+++ b/src/pending_bundle.rs
@@ -28,7 +28,7 @@ use thiserror::Error;
 /// [fb_debug]: https://docs.flashbots.net/flashbots-auction/searchers/faq/#why-didnt-my-transaction-get-included
 #[pin_project]
 pub struct PendingBundle<'a, P> {
-    pub bundle_hash: BundleHash,
+    pub bundle_hash: Option<BundleHash>,
     pub block: U64,
     pub transactions: Vec<TxHash>,
     provider: &'a Provider<P>,
@@ -38,7 +38,7 @@ pub struct PendingBundle<'a, P> {
 
 impl<'a, P: JsonRpcClient> PendingBundle<'a, P> {
     pub fn new(
-        bundle_hash: BundleHash,
+        bundle_hash: Option<BundleHash>,
         block: U64,
         transactions: Vec<TxHash>,
         provider: &'a Provider<P>,
@@ -55,13 +55,13 @@ impl<'a, P: JsonRpcClient> PendingBundle<'a, P> {
 
     /// Get the bundle hash for this pending bundle.
     #[deprecated(note = "use the bundle_hash field instead")]
-    pub fn bundle_hash(&self) -> BundleHash {
+    pub fn bundle_hash(&self) -> Option<BundleHash> {
         self.bundle_hash
     }
 }
 
 impl<'a, P: JsonRpcClient> Future for PendingBundle<'a, P> {
-    type Output = Result<BundleHash, PendingBundleError>;
+    type Output = Result<Option<BundleHash>, PendingBundleError>;
 
     fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
         let this = self.project();

--- a/src/relay.rs
+++ b/src/relay.rs
@@ -72,7 +72,7 @@ impl<S: Signer> Relay<S> {
         &self,
         method: &str,
         params: T,
-    ) -> Result<R, RelayError<S>> {
+    ) -> Result<Option<R>, RelayError<S>> {
         let next_id = self.id.load(Ordering::SeqCst) + 1;
         self.id.store(next_id, Ordering::SeqCst);
 
@@ -139,7 +139,7 @@ impl<S: Signer + Clone> Clone for Relay<S> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SendBundleResponse {
-    pub(crate) bundle_hash: BundleHash,
+    pub(crate) bundle_hash: Option<BundleHash>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
GM!

Currently ethers-flashbots fails on deserialization for those builders (ex. builder0x69) that do not send `bundle_hash` as an immediate response. I have implemented some tweaks to support them all by making response's data filed an `Option<R>`.

Please, let me know if I shall make any other changes.